### PR TITLE
fixes stream exception when running on python 3.8

### DIFF
--- a/bin/json-dotenv
+++ b/bin/json-dotenv
@@ -278,7 +278,7 @@ class JsonDotEnv(object): # pylint: disable=bad-option-value,useless-object-inhe
 
         return self._output(
             self._format(
-                dotenv.dotenv_values(self.fcontent)))
+                dotenv.dotenv_values(stream=self.fcontent)))
 
     def do_keys(self):
         self._parse_file()


### PR DESCRIPTION
When running json-dotenv on python 3.8 I got this exception:

```ERROR:2021-09-06 17:38:48: stat: path should be string, bytes, os.PathLike or integer, not _io.StringIO
Traceback (most recent call last):
  File "/Users/andreas/develop/scratch/json-dotenv/bin/json-dotenv", line 407, in main
    getattr(JsonDotEnv(options), "do_%s" % options.command)()
  File "/Users/andreas/develop/scratch/json-dotenv/bin/json-dotenv", line 281, in do_list
    dotenv.dotenv_values(self.fcontent)))
  File "/Users/andreas/develop/scratch/json-dotenv/.venv/lib/python3.8/site-packages/dotenv/main.py", line 353, in dotenv_values
    return DotEnv(
  File "/Users/andreas/develop/scratch/json-dotenv/.venv/lib/python3.8/site-packages/dotenv/main.py", line 74, in dict
    self._dict = OrderedDict(resolve_variables(raw_values, override=self.override))
  File "/Users/andreas/develop/scratch/json-dotenv/.venv/lib/python3.8/site-packages/dotenv/main.py", line 218, in resolve_variables
    for (name, value) in values:
  File "/Users/andreas/develop/scratch/json-dotenv/.venv/lib/python3.8/site-packages/dotenv/main.py", line 81, in parse
    with self._get_stream() as stream:
  File "/Library/Developer/CommandLineTools/Library/Frameworks/Python3.framework/Versions/3.8/lib/python3.8/contextlib.py", line 113, in __enter__
    return next(self.gen)
  File "/Users/andreas/develop/scratch/json-dotenv/.venv/lib/python3.8/site-packages/dotenv/main.py", line 53, in _get_stream
    if self.dotenv_path and os.path.isfile(self.dotenv_path):
  File "/Library/Developer/CommandLineTools/Library/Frameworks/Python3.framework/Versions/3.8/lib/python3.8/genericpath.py", line 30, in isfile
    st = os.stat(path)
TypeError: stat: path should be string, bytes, os.PathLike or integer, not _io.StringIO
```

This fixes the problem, by explicitly setting the object type.